### PR TITLE
Bug 1155418 - Preview of images are just overlayed on top

### DIFF
--- a/lib/views/create-bug.js
+++ b/lib/views/create-bug.js
@@ -35,19 +35,25 @@ function deleteAttachment(e) {
   bugChanged();
 };
 
-function previewAttachment(file) {
-  var preview = document.createElement('div');
-
-  preview.classList.add('preview');
-  preview.style.backgroundImage =
-    'url(data:' + file.type + ';base64,' + file.data + ')';
-
-  preview.addEventListener('click', function() {
-    document.body.removeChild(preview);
-  });
-
-  document.body.appendChild(preview);
-};
+function previewAttachment(attachment) {
+  if (typeof(MozActivity) !== 'undefined') {
+    var activity = new MozActivity({
+      name: 'open',
+      data: {
+        type: attachment.type,
+        filename: attachment.name,
+        blob: attachment.blob,
+        exitWhenHidden: true
+      }
+    });
+    activity.onerror = function() {
+      console.warn('Problem with "open" activity', activity.error.name);
+    };
+  } else {
+    var objectURL = URL.createObjectURL(attachment.blob);
+    window.open(objectURL);
+  }
+}
 
 function drawAttachments() {
   tpl.read('/views/attachment-row.tpl').then(function(row) {
@@ -63,12 +69,7 @@ function drawAttachments() {
     bug.attachments.map(function(file) {
       var dom = row.cloneNode(true);
       var a = dom.querySelector('a');
-      var bytes = Math.round((file.data.length - 814) / 1.37);
-      // Tiny files will be negative due to approximiating base64
-      // compression size
-      if (bytes < 0) {
-        bytes = 0;
-      }
+      var bytes = file.blob.size || 0;
       dom.querySelector('.name').textContent = file.name;
       dom.querySelector('.size').textContent = filesize(bytes, {round: 0});
       a.dataset.name = file.name;
@@ -87,42 +88,52 @@ function drawAttachments() {
   });
 }
 
-// We currently base64 all incoming files as that is what the bmo
-// API needs anyway, may want to avoid encoding until they are sent
+// Add the file blobs from the input event to the bug's attachments and render
+// the attachment list.
 function inputChanged(e) {
   var files = e.target.files;
   var attachments = [];
   for (var i = 0; i < files.length; i++) {
-    attachments.push(pushAttachment(files.item(i)));
+    pushAttachment(files.item(i));
   }
-  Promise.all(attachments).then(bugChanged);
+  bugChanged();
 }
 
-// Add the blobs coming from the capture logs activity
-// to the current bug.
+// Add the blobs coming from the capture logs activity to the current bug's
+// attachments and render the attachment list.
 function addActivityAttachments(blobs, names) {
-  Promise.all(blobs.map(function(blob, i) {
-    return pushAttachment(blob, names[i]);
-  })).then(bugChanged);
+  blobs.forEach(function(blob, i) {
+    pushAttachment(blob, names[i]);
+  });
+  bugChanged();
 }
 
-
+// Add a single attachment, keeping track of the file's Blob to base64 encode
+// later.
 function pushAttachment(file, name) {
-  return new Promise(function(resolve) {
+  bug.attachments.push({
+    name: name || file.name,
+    type: file.type,
+    blob: file
+  });
+}
+
+// Read an attachment's file Blob, returning a Promise that will be resolved
+// with the base64 encoding of the file's contents.
+function encodeAttachment(attachment) {
+  return new Promise(function(resolve, reject) {
     var reader = new FileReader();
     reader.onload = function(e) {
-      bug.attachments.push({
-        name: name || file.name,
-        type: file.type,
-        data: e.target.result.split(',')[1]
-      });
-      resolve();
+      // Extract the raw base64 data from a base64 data url
+      var dataUrl = e.target.result;
+      var base64Data = dataUrl.split(',')[1];
+      resolve(base64Data);
     };
     reader.onerror = reader.onabort = function(error) {
       console.error('Error reading file attachment', error);
       reject(error);
     };
-    reader.readAsDataURL(file);
+    reader.readAsDataURL(attachment.blob);
   });
 }
 
@@ -196,12 +207,14 @@ function submitBug() {
         return;
       }
       var file = bug.attachments.pop();
-      app.bugzilla.createAttachment(id, {
-        ids: [id],
-        data: file.data,
-        file_name: file.name,
-        summary: file.name,
-        content_type: file.type || 'application/octet-stream'
+      encodeAttachment(file).then(function(data) {
+        return app.bugzilla.createAttachment(id, {
+          ids: [id],
+          data: data,
+          file_name: file.name,
+          summary: file.name,
+          content_type: file.type || 'application/octet-stream'
+        });
       }).then(function() {
         createAttachments();
       }).catch(function() {


### PR DESCRIPTION
Fixes 1155418 by using "open" MozActivity for attachment previewing. Additionally switches base64 encoding of attachments to be performed lazily on upload. 