### PR TITLE
Bug 1198695 - If the user enters text into the comments box and then …

### DIFF
--- a/lib/views/bug-comments.js
+++ b/lib/views/bug-comments.js
@@ -49,9 +49,23 @@ module.exports = function(ctx) {
     });
 
     var submit = page.querySelector('input[type=submit]');
-    var remove = submit.removeAttribute.bind(submit, 'disabled');
-    form.addEventListener('change', remove);
+
+    var remove = function() {
+      if (comment.value) {
+        submit.removeAttribute('disabled');
+      } else {
+        submit.setAttribute('disabled', 'disabled');
+      }
+    };
+
     form.addEventListener('input', remove);
+
+    var select = page.querySelector('select');
+
+    select.addEventListener('change', function() {
+      submit.removeAttribute('disabled');
+      form.removeEventListener('input', remove, false);
+    });
 
     form.addEventListener('submit', function(e) {
       e.preventDefault();


### PR DESCRIPTION
…deletes it, the ‘save changes’ button should be disabled again